### PR TITLE
Only include match arguments highlighting for ambiguous steps

### DIFF
--- a/java/src/main/java/io/cucumber/jsonformatter/JsonReportWriter.java
+++ b/java/src/main/java/io/cucumber/jsonformatter/JsonReportWriter.java
@@ -396,6 +396,8 @@ final class JsonReportWriter {
 
     private List<JvmArgument> createJvmArguments(TestStep step) {
         return step.getStepMatchArgumentsLists()
+                // Only include arguments for unambiguous steps
+                .filter(stepMatchArgumentsLists -> stepMatchArgumentsLists.size() == 1)
                 .map(argumentsLists -> argumentsLists.stream()
                         .map(StepMatchArgumentsList::getStepMatchArguments)
                         .flatMap(Collection::stream)


### PR DESCRIPTION
### ⚡️ What's your motivation? 

Only unambiguous steps, i.e. steps with a single list of matches should be included in the report(?).

### 🏷️ What kind of change is this?

- :bug: Bug fix (non-breaking change which fixes a defect)

- [ ] Add sample from Cucumber-JVM 7.26.0 with ambiguous steps with arguments
- [ ] https://github.com/cucumber/compatibility-kit/pull/156 for verification
- [x] I agree to respect and uphold the [Cucumber Community Code of Conduct](https://github.com/cucumber/.github/tree/main?tab=coc-ov-file)
- [ ] I've changed the behaviour of the code
  - [ ] I have added/updated tests to cover my changes.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly.
- [ ] Users should know about my change
  - [ ] I have added an entry to the "Unreleased" section of the [**CHANGELOG**](../blob/main/CHANGELOG.md), linking to this pull request.
