### PR TITLE
Fix attachment rendering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,10 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Fix attachment rendering ([#12](https://github.com/cucumber/cucumber-json-formatter/pull/7))
 
 ## [0.1.2] - 2025-09-03
 ### Fixed
-- `JvmArgument.val` and `JvmArgument.offset` are not required in practice  ([#7](https://github.com/cucumber/cucumber-json-formatter/pull/7) M.P. Korstanje)
+- `JvmArgument.val` and `JvmArgument.offset` are not required in practice  ([#7](https://github.com/cucumber/cucumber-json-formatter/pull/7))
 
 ## [0.1.1] - 2025-07-24
 ### Fixed
@@ -17,7 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.1.0] - 2025-07-24
 ### Added
-- Java implementation ([#1](https://github.com/cucumber/cucumber-json-formatter/pull/1) M.P. Korstanje)
+- Java implementation ([#1](https://github.com/cucumber/cucumber-json-formatter/pull/1))
 
 [Unreleased]: https://github.com/cucumber/cucumber-json-formatter/compare/v0.1.2...HEAD
 [0.1.2]: https://github.com/cucumber/cucumber-json-formatter/compare/v0.1.1...v0.1.2

--- a/testdata/compatibility-kit/attachments.ndjson.jvm.json
+++ b/testdata/compatibility-kit/attachments.ndjson.jvm.json
@@ -37,8 +37,11 @@
               "duration": 1000000,
               "status": "passed"
             },
-            "output": [
-              "hello"
+            "embeddings": [
+              {
+                "mime_type": "application/octet-stream",
+                "data": "aGVsbG8="
+              }
             ]
           }
         ]
@@ -131,8 +134,11 @@
               "line": 25,
               "value": "{\"message\": \"The <b>big</b> question\", \"foo\": \"bar\"}"
             },
-            "output": [
-              "{\"message\": \"The <b>big</b> question\", \"foo\": \"bar\"}"
+            "embeddings": [
+              {
+                "mime_type": "application/json",
+                "data": "eyJtZXNzYWdlIjogIlRoZSA8Yj5iaWc8L2I+IHF1ZXN0aW9uIiwgImZvbyI6ICJiYXIifQ=="
+              }
             ]
           }
         ]
@@ -232,8 +238,11 @@
               "duration": 1000000,
               "status": "passed"
             },
-            "output": [
-              "https://cucumber.io"
+            "embeddings": [
+              {
+                "mime_type": "text/uri-list",
+                "data": "aHR0cHM6Ly9jdWN1bWJlci5pbw=="
+              }
             ]
           }
         ]


### PR DESCRIPTION

### ⚡️ What's your motivation? 

In Cucumber JVM attachments can be created in a few different ways. How influences whether the attachment ends up as elements of `embeddings` or `output`.

| Method                         | Encoding | Media Type                | Destination  |
| ------------------------------ | -------- | ------------------------- | ------------ |
| `Scenario.attach(byte[], ...)` | BASE64   | any, from method          | `embeddings` |
| `Scenario.attach(String, ...)` | IDENTITY | any, from method          | `embeddings` |
| `Scenario.log(String)`         | IDENTITY | text/x.cucumber.log+plain | `output`     |

Originally the implementation determined the destination based on the encoding, but this is obviously not correct. An alternative would be to select on the media type.

This does come with the disadvantage that `Scenario.attach` also takes in a media type argument. So in theory that could be `text/x.cucumber.log+plain` but for now we'll assume that is not the case.

Should this assumption prove wrong we could match on both encoding and media type, but it would be more reasonable for the user to change their code.

Fixes: https://github.com/cucumber/cucumber-jvm/issues/3069

### 🏷️ What kind of change is this?
- :bug: Bug fix (non-breaking change which fixes a defect)

### ♻️ Anything particular you want feedback on?

If you are using `text/x.cucumber.log+plain` in combination with `Scenario.attach` please let us know your use case.

### 📋 Checklist:

- [x] I agree to respect and uphold the [Cucumber Community Code of Conduct](https://github.com/cucumber/.github/tree/main?tab=coc-ov-file)
- [x] I've changed the behaviour of the code
  - [x] I have added/updated tests to cover my changes.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly.
- [x] Users should know about my change
  - [x] I have added an entry to the "Unreleased" section of the [**CHANGELOG**](../blob/main/CHANGELOG.md), linking to this pull request.
